### PR TITLE
fix: fix redirect link to `state-as-a-snapshot`

### DIFF
--- a/src/content/learn/state-a-components-memory.md
+++ b/src/content/learn/state-a-components-memory.md
@@ -1460,7 +1460,7 @@ export default function FeedbackForm() {
 当按钮被点击时，这个例子应该询问用户的名字，然后显示一个 alert 欢迎他们。你尝试使用 state 来保存名字，但由于某种原因，它始终显示“Hello, ！”。
 
 
-要修复此代码，请删除不必要的 state 变量。（我们将在稍后讨论[为什么上述代码不起作用](/learn/troubleshooting-state-updates#setting-state-does-not-update-variables)。）
+要修复此代码，请删除不必要的 state 变量。（我们将在稍后讨论[为什么上述代码不起作用](/learn/state-as-a-snapshot)。）
 
 你能解释为什么这个 state 变量是不必要的吗？
 


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/reactjs/react.dev/issues/6085)