### PR TITLE
Update cloneElement.md

### DIFF
--- a/src/content/reference/react/cloneElement.md
+++ b/src/content/reference/react/cloneElement.md
@@ -40,7 +40,7 @@ const clonedElement = cloneElement(
   'Goodbye'
 );
 
-console.log(clonedElement); // <Row title="Cabbage">Goodbye</Row>
+console.log(clonedElement); // <Row title="Cabbage" isHighlighted={true}>Goodbye</Row>
 ```
 
 [请参阅下面的更多示例](#usage)。


### PR DESCRIPTION
代码示例中，第二个参数，即props对象，存在`isHighlighted: true`，但是在最终console输出的注释里，却没有加上这个属性，查看英文原文档，也同样没加，不知道是有意为止还是此处只是想强调children的替换呢？

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
