### PR TITLE
docs(cn): improve learn/you-might-need-an-effect translation

### DIFF
--- a/src/content/learn/you-might-not-need-an-effect.md
+++ b/src/content/learn/you-might-not-need-an-effect.md
@@ -24,7 +24,7 @@ Effect 是 React 范式中的一个逃脱方案。它们让你可以 “逃出�
 有两种不必使用 Effect 的常见情况：
 
 * **你不必使用 Effect 来转换渲染所需的数据**。例如，你想在展示一个列表前先做筛选。你的直觉可能是写一个当列表变化时更新 state 变量的 Effect。然而，这是低效的。当你更新这个 state 时，React 首先会调用你的组件函数来计算应该显示在屏幕上的内容。然后 React 会把这些变化“[提交](/learn/render-and-commit)”到 DOM 中来更新屏幕。然后 React 会执行你的 Effect。如果你的 Effect 也立即更新了这个 state，就会重新执行整个流程。为了避免不必要的渲染流程，应在你的组件顶层转换数据。这些代码会在你的 props 或 state 变化时自动重新执行。
-* **你不必使用 Effect 来处理用户事件**。例如，你想在用户购买一个产品时发送一个 `/api/buy` 的 POST 请求并展示一个提示。在这个购买按钮的点击事件处理函数中，你确切地知道会发生什么。但是你不知道用户做了什么导致 Effect 被执行（例如，点击了某个按钮）。这就是为什么你通常应该在相应的事件处理函数中处理用户事件。
+* **你不必使用 Effect 来处理用户事件**。例如，你想在用户购买一个产品时发送一个 `/api/buy` 的 POST 请求并展示一个提示。在这个购买按钮的点击事件处理函数中，你确切地知道会发生什么。但是当一个 Effect 运行时，你却不知道用户做了什么（例如，点击了哪个按钮）。这就是为什么你通常应该在相应的事件处理函数中处理用户事件。
 
 你 **的确** 可以使用 Effect 来和外部系统 [同步](/learn/synchronizing-with-effects#what-are-effects-and-how-are-they-different-from-events) 。例如，你可以写一个 Effect 来保持一个 jQuery 的组件和 React state 之间的同步。你也可以使用 Effect 来获取数据：例如，你可以同步当前的查询搜索和查询结果。请记住，比起直接在你的组件中写 Effect，现代 [框架](/learn/start-a-new-react-project#production-grade-react-frameworks) 提供了更加高效的，内置的数据获取机制。
 


### PR DESCRIPTION
原文：
> In the Buy button click event handler, you know exactly what happened. By the time an Effect runs, you don’t know what the user did (for example, which button was clicked).

我觉得原文是想强调：在事件的回调函数里，我们自然地知晓发生了什么，因为我们查看这个事件回调函数由哪个事件触发的就一目了然。但是如果此时有一个Effect运行了，我们无法根据这个Effect来推断出，用户到底做了什么。

线上的翻译我读上去总觉得有点别扭，感觉没有表达出英文想表达的~