### PR TITLE
fix: correct translations

### DIFF
--- a/src/content/learn/synchronizing-with-effects.md
+++ b/src/content/learn/synchronizing-with-effects.md
@@ -609,7 +609,7 @@ useEffect(() => {
 }, [zoomLevel]);
 ```
 
-请注意，在这种情况下不需要清理。在开发环境中，React 会调用 Effect 两次，但这两次挂载时依赖项 `setZoomLevel` 都是相同的，所以会跳过执行第二次挂载时的 Effect。开发环境中它可能会稍微慢一些，但这问题不大，因为它在生产中不会进行不必要的重复挂载。
+请注意，在这种情况下不需要清理。在开发环境中，React 会调用 Effect 两次，但这两次挂载时依赖项 `zoomLevel` 都是相同的，所以会跳过执行第二次挂载时的 Effect。开发环境中它可能会稍微慢一些，但这问题不大，因为它在生产中不会进行不必要的重复挂载。
 
 某些 API 可能不允许连续调用两次。例如，内置的 [`<dialog>`](https://developer.mozilla.org/zh-CN/docs/Web/API/HTMLDialogElement) 元素的 [`showModal`](https://developer.mozilla.org/zh-CN/docs/Web/API/HTMLDialogElement/showModal) 方法在连续调用两次时会抛出异常，此时实现清理函数并使其关闭对话框：
 


### PR DESCRIPTION

英文版本：

> React will call the Effect twice, but this is not a problem because calling setZoomLevel twice with the same value does not do anything.

线上的翻译：

React 会调用 Effect 两次，但这不是问题，使用相同的值调用 setZoomLevel 两次不会执行任何操作。 

翻译优化成：
> 但这两次挂载时 setZoomLevel 的依赖项都是相同的

或

> 但这两次挂载时依赖项 zoomLevel 都是相同的

或许会更好