### PR TITLE
docs(cn): translate title tag of use-server and use-client

### DIFF
--- a/src/content/reference/react/use-client.md
+++ b/src/content/reference/react/use-client.md
@@ -1,6 +1,6 @@
 ---
 title: "'use client'"
-titleForTitleTag: "'use client' directive"
+titleForTitleTag: "'use client' 指示符"
 canary: true
 ---
 

--- a/src/content/reference/react/use-server.md
+++ b/src/content/reference/react/use-server.md
@@ -1,6 +1,6 @@
 ---
 title: "'use server'"
-titleForTitleTag: "'use server' directive"
+titleForTitleTag: "'use server' 指示符"
 canary: true
 ---
 


### PR DESCRIPTION
翻译 `use-server` 与 `use-client` 的 title tag。