### PR TITLE
fix: unify the translation of `describing-the-ui`

### DIFF
--- a/src/content/learn/describing-the-ui.md
+++ b/src/content/learn/describing-the-ui.md
@@ -1,5 +1,5 @@
 ---
-title: 描述用户界面
+title: 描述 UI
 translators:
   - ChelesteWang
   - QC-L

--- a/src/sidebarLearn.json
+++ b/src/sidebarLearn.json
@@ -51,7 +51,7 @@
       "sectionHeader": "学习 React"
     },
     {
-      "title": "描述用户界面",
+      "title": "描述 UI",
       "tags": [],
       "path": "/learn/describing-the-ui",
       "routes": [


### PR DESCRIPTION
before:
<img width="1440" alt="image" src="https://github.com/reactjs/zh-hans.react.dev/assets/69381867/7cf87dc6-8647-4fca-9a0c-93c370d60ffc">
<img width="1440" alt="image" src="https://github.com/reactjs/zh-hans.react.dev/assets/69381867/5e7406bf-6190-4e00-a20f-a63e0694acd0">

current:
全部统一翻译成 `描述 UI`
理念：UI 这种词汇个人理解不需要使用 user interface 来进行翻译
