### PR TITLE
chore: unify data desc in `learn/rendering-lists`

### DIFF
--- a/src/content/learn/rendering-lists.md
+++ b/src/content/learn/rendering-lists.md
@@ -105,24 +105,24 @@ Warning: Each child in a list should have a unique "key" prop.
 ```js
 const people = [{
   id: 0,
-  name: 'Creola Katherine Johnson',
-  profession: 'mathematician',
+  name: '凯瑟琳·约翰逊',
+  profession: '数学家',
 }, {
   id: 1,
-  name: 'Mario José Molina-Pasquel Henríquez',
-  profession: 'chemist',
+  name: '马里奥·莫利纳',
+  profession: '化学家',
 }, {
   id: 2,
-  name: 'Mohammad Abdus Salam',
-  profession: 'physicist',
+  name: '穆罕默德·阿卜杜勒·萨拉姆',
+  profession: '物理学家',
 }, {
   id: 3,
-  name: 'Percy Lavon Julian',
-  profession: 'chemist',  
+  name: '珀西·莱温·朱利亚',
+  profession: '化学家',
 }, {
   id: 4,
-  name: 'Subrahmanyan Chandrasekhar',
-  profession: 'astrophysicist',
+  name: '苏布拉马尼扬·钱德拉塞卡',
+  profession: '天体物理学家',
 }];
 ```
 


### PR DESCRIPTION
其他位置的科学家全部翻译成中文了，这一处建议一起翻译了。
before:
<img width="1175" alt="image" src="https://github.com/reactjs/zh-hans.react.dev/assets/69381867/8b45fb12-e8ac-412e-9458-5a60bfe63893">
<img width="1217" alt="image" src="https://github.com/reactjs/zh-hans.react.dev/assets/69381867/ab71efa7-8a82-4691-8d44-0a80e0c69d48">
current:
<img width="1512" alt="image" src="https://github.com/reactjs/zh-hans.react.dev/assets/69381867/9d91ae1e-7f97-4fb6-bd6e-8f207621d92c">

