### PR TITLE
fix: correct useActionState to useFormState

### DIFF
--- a/src/content/blog/2024/04/25/react-19.md
+++ b/src/content/blog/2024/04/25/react-19.md
@@ -168,7 +168,7 @@ const [error, submitAction, isPending] = useActionState(
 
 <Note>
 
-`React.useActionState` 在 Canary 版本中曾被称为 `ReactDOM.useActionState`，但我们已经将其重命名并弃用了 `useActionState`。
+`React.useActionState` 在 Canary 版本中曾被称为 `ReactDOM.useFormState`，但我们已经将其重命名并弃用了 `useFormState`。
 
 有关更多信息，请参见 [#28491](https://github.com/facebook/react/pull/28491)。
 


### PR DESCRIPTION
## 更正 /blog/2024/04/25/react-19 useFormState 错误迁移为 useActionState
![image](https://github.com/reactjs/zh-hans.react.dev/assets/51431425/cc33ff0e-a5aa-400f-bab0-4cd3fb916fdd)
![image](https://github.com/reactjs/zh-hans.react.dev/assets/51431425/b2fd4055-078a-4bea-9cfb-c337c100d5ff)

## 更正后

![image](https://github.com/reactjs/zh-hans.react.dev/assets/51431425/701867c8-f79a-40d3-bdf4-919ef67f8d8d)

