### PR TITLE
docs(cn): fix inconsistent link text for "State: 组件的记忆" page to match…

### DIFF
--- a/src/content/learn/passing-props-to-a-component.md
+++ b/src/content/learn/passing-props-to-a-component.md
@@ -414,7 +414,7 @@ export default function App() {
 
 然而，props 是 [不可变的](https://en.wikipedia.org/wiki/Immutable_object)（一个计算机科学术语，意思是“不可改变”）。当一个组件需要改变它的 props（例如，响应用户交互或新数据）时，它不得不“请求”它的父组件传递 **不同的 props** —— 一个新对象！它的旧 props 将被丢弃，最终 JavaScript 引擎将回收它们占用的内存。
 
-**不要尝试“更改 props”。** 当你需要响应用户输入（例如更改所选颜色）时，你可以“设置 state”，你可以在 [State: 一个组件的内存](/learn/state-a-components-memory) 中继续了解。
+**不要尝试“更改 props”。** 当你需要响应用户输入（例如更改所选颜色）时，你可以“设置 state”，你可以在 [State：组件的记忆](/learn/state-a-components-memory) 中继续了解。
 
 <Recap>
 


### PR DESCRIPTION
### Fixes
Unified the link text "State: 一个组件的内存" to "State: 组件的记忆" to match the target page title and improve consistency.

### Background
The current link text is inconsistent with the target page title, which may confuse users into thinking they’ve navigated to the wrong page.

The original English title is "State: A Component’s Memory," translated as "组件的记忆."

### 修复内容

- 将“State: 一个组件的内存”链接文字统一为“State：组件的记忆”，与跳转后页面标题一致，提升一致性。

### 背景说明

- 当前链接文字与目标页面标题不一致，可能导致用户以为跳错了。
- 原文为 "State: A Component’s Memory"，翻译标题为“组件的记忆”。

https://zh-hans-react-m3iriq75x-fbopensource.vercel.app/learn/passing-props-to-a-component#how-props-change-over-time