### PR TITLE
docs: Fix external link to zh.javascript.info

### DIFF
--- a/src/content/learn/index.md
+++ b/src/content/learn/index.md
@@ -79,7 +79,7 @@ export default function MyApp() {
 
 </Sandpack>
 
-`export default` 关键字指定了文件中的主要组件。如果你对 JavaScript 某些语法不熟悉，可以参考 [MDN](https://developer.mozilla.org/zh-CN/docs/web/javascript/reference/statements/export) 和 [javascript.info](https://javascript.info/import-export)。
+`export default` 关键字指定了文件中的主要组件。如果你对 JavaScript 某些语法不熟悉，可以参考 [MDN](https://developer.mozilla.org/zh-CN/docs/web/javascript/reference/statements/export) 和 [javascript.info](https://zh.javascript.info/import-export)。
 
 ## 使用 JSX 编写标签 {/*writing-markup-with-jsx*/}
 


### PR DESCRIPTION
<img width="1673" height="1098" alt="clipboard_2025-08-16_23-39" src="https://github.com/user-attachments/assets/4d220ab9-063f-4de6-8703-50b778296eca" />

[As shown in the attached screenshot](https://zh-hans.react.dev/learn#components), one of the external links still points to the English version of **javascript.info,** while the **MDN** link already points to the Simplified Chinese page.

This PR updates the **javascript.info** link to its Simplified Chinese version for consistency:

https://javascript.info/import-export -> https://zh.javascript.info/import-export