### PR TITLE
docs: fix dead link on manipulating-the-dom-with-refs.md

### DIFF
--- a/src/content/learn/manipulating-the-dom-with-refs.md
+++ b/src/content/learn/manipulating-the-dom-with-refs.md
@@ -79,7 +79,7 @@ export default function Form() {
 
 1. 使用 `useRef` Hook 声明 `inputRef`。
 2. 像 `<input ref={inputRef}>` 这样传递它。这告诉 React **将这个 `<input>` 的 DOM 节点放入 `inputRef.current`。**
-3. 在 `handleClick` 函数中，从 `inputRef.current` 读取 input DOM 节点并使用 `inputRef.current.focus()` 调用它的 [`focus()`](https://developer.mozilla.org/zh-CN/docs/Web/API/HTMLElement/focus)。
+3. 在 `handleClick` 函数中，从 `inputRef.current` 读取 input DOM 节点并使用 `inputRef.current.focus()` 调用它的 [`focus()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus)。
 4. 用 `onClick` 将 `handleClick` 事件处理器传递给 `<button>`。
 
 虽然 DOM 操作是 ref 最常见的用例，但 `useRef` Hook 可用于存储 React 之外的其他内容，例如计时器 ID 。与 state 类似，ref 能在渲染之间保留。你甚至可以将 ref 视为设置它们时不会触发重新渲染的 state 变量！你可以在[使用 Ref 引用值](/learn/referencing-values-with-refs)中了解有关 ref 的更多信息。


### PR DESCRIPTION
## [dead link](https://zh-hans.react.dev/learn/manipulating-the-dom-with-refs#example-focusing-a-text-input)
<img width="937" height="395" alt="image" src="https://github.com/user-attachments/assets/f510c717-f461-4086-9112-fed576c0dc4e" />

open after, I fix link to en version
<img width="1170" height="548" alt="image" src="https://github.com/user-attachments/assets/9aca0583-829f-4764-994b-cf5833fd655a" />
