### PR TITLE
docs: fix dead link on useEffect.md

### DIFF
--- a/src/content/reference/react/useEffect.md
+++ b/src/content/reference/react/useEffect.md
@@ -368,7 +368,7 @@ html, body { min-height: 300px; }
 
 #### 控制模态对话框 {/*controlling-a-modal-dialog*/}
 
-在这个例子中，外部系统是浏览器 DOM。`ModalDialog` 组件渲染一个 [`<dialog>`](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/dialog) 元素。它使用 Effect 将 `isOpen` prop 同步到 [`showModal()`](https://developer.mozilla.org/zh-CN/docs/Web/API/HTMLDialogElement/showModal) 和 [`close()`](https://developer.mozilla.org/zh-CN/docs/Web/API/HTMLDialogElement/close) 方法调用。
+在这个例子中，外部系统是浏览器 DOM。`ModalDialog` 组件渲染一个 [`<dialog>`](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/dialog) 元素。它使用 Effect 将 `isOpen` prop 同步到 [`showModal()`](https://developer.mozilla.org/zh-CN/docs/Web/API/HTMLDialogElement/showModal) 和 [`close()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/close) 方法调用。
 
 <Sandpack>
 


### PR DESCRIPTION
## [dead link](https://zh-hans.react.dev/reference/react/useEffect#connecting-to-an-external-system)
<img width="1353" height="502" alt="image" src="https://github.com/user-attachments/assets/e3b4cbe5-dc7b-4fb6-8b6b-bf1962011eca" />

open after
<img width="1124" height="531" alt="image" src="https://github.com/user-attachments/assets/06a63d4c-8699-4015-9b5d-84d41584a8ba" />

I fix zh to en link